### PR TITLE
Say hello

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -606,6 +606,24 @@ app.get('/api/hobby-plans', async (req, res) => {
   } catch { res.json([]); }
 });
 
+// GET single hobby plan by id (read-only)
+app.get('/api/hobby-plans/:id', async (req, res) => {
+  try {
+    const id = String(req.params.id || '');
+    if (!id || !supabaseAnon) return res.status(404).json({ error: 'not_found' });
+    const { data, error } = await supabaseAnon
+      .from('hobby_plans')
+      .select('*')
+      .eq('id', id)
+      .limit(1)
+      .maybeSingle();
+    if (error || !data) return res.status(404).json({ error: 'not_found' });
+    res.json(data);
+  } catch {
+    res.status(404).json({ error: 'not_found' });
+  }
+});
+
 // Chat moderation helper
 function isUnsafeQuery(text: string): { unsafe: boolean; category?: string } {
   const lowered = text.toLowerCase();


### PR DESCRIPTION
Add fallback to load plan data on the split page when navigating from the dashboard's "Continue Learning" button.

Previously, the split page might not load the correct plan if `initialPlanData` was missing, leading to a blank or initial state. This change ensures the plan is restored from session storage or fetched via `plan_id` and `user_id`, providing a consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b927e2-0207-47b1-84c2-8def9746db75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19b927e2-0207-47b1-84c2-8def9746db75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

