### PR TITLE
Say hello

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -30,4 +30,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://www.wizqo.com/cookies</loc>
+    <lastmod>2024-08-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import { AboutPage } from './pages/AboutPage';
 import { ContactPage } from './pages/ContactPage';
 import { PrivacyPage } from './pages/PrivacyPage';
 import { TermsPage } from './pages/TermsPage';
+import { CookiesPage } from './pages/CookiesPage';
 import { ResetPasswordPage } from './pages/ResetPasswordPage';
 import { SEOMetaTags } from './components/SEOMetaTags';
 
@@ -376,6 +377,17 @@ export default function App() {
                     canonicalUrl="https://wizqo.com/terms"
                   />
                   <TermsPage />
+                </>
+              );
+            case 'cookies':
+              return (
+                <>
+                  <SEOMetaTags 
+                    title="Cookie Policy - How Wizqo Uses Cookies | Transparent Data Practice"
+                    description="Understand how Wizqo uses cookies to enhance your learning experience. Comprehensive cookie policy covering types, purposes, and your control options."
+                    canonicalUrl="https://wizqo.com/cookies"
+                  />
+                  <CookiesPage />
                 </>
               );
             case 'reset-password':

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,15 @@
       }
     },
     {
+      "source": "/cookies",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "index, follow"
+        }
+      ]
+    },
+    {
       "src": "server/index.ts",
       "use": "@vercel/node@3.0.0",
       "config": {


### PR DESCRIPTION
Restore the `/cookies` page by re-adding its client-side route, SEO metadata, and sitemap entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-b18bdd81-2fab-4498-ae9d-03c461462fd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b18bdd81-2fab-4498-ae9d-03c461462fd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

